### PR TITLE
add auto-imports.d.ts to tsconfig include for AutoImport support

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,7 @@
     "include": [
         "resources/js/**/*.ts",
         "resources/js/**/*.d.ts",
-        "resources/js/**/*.vue"
+        "resources/js/**/*.vue",
+        "auto-imports.d.ts"
     ]
 }


### PR DESCRIPTION
I added auto-imports.d.ts to the array in the tsconfig.json file to enable the AutoImport plugin for TypeScript files as well.